### PR TITLE
Added a way to configure Poulda behind a proxy with a different path pre...

### DIFF
--- a/poulda/app.py
+++ b/poulda/app.py
@@ -14,7 +14,7 @@ def make_app(global_config, **settings):
     if not nginx_upload_progress:
         from poulda.models import initialize_db
         initialize_db(settings['poulda.db_url'])
-    config = Configurator(settings=settings)
+    config = Configurator(settings=settings,route_prefix=settings.get('pyramid.route_prefix'))
 
     # Authentication and authorization policies
     auth_policy = AuthTktAuthenticationPolicy(settings['poulda.secret'])


### PR DESCRIPTION
I wanted to put Poulda behind an Apache server with mod_proxy with a path prefix.
Pyramid allows to do this using the route_prefix option.

I've added this change to make it possible trough configuration.

```
pyramid.route_prefix=/upload
```

In the configuration I've also added this to make it work with https

```
filter-with = proxy-prefix
[filter:proxy-prefix]
use = egg:PasteDeploy#prefix
scheme=https
```

Here's the proxy configuration part for Apache 

```
[...]
        <Location /upload>
                ProxyPass  http://127.0.0.1:6543/upload retry=5
                ProxyPassReverse  http://127.0.0.1:6543/upload
                allow from all
        </Location>
[...]
```
